### PR TITLE
dedent code before parsing in order to support nested functions

### DIFF
--- a/compiler.py
+++ b/compiler.py
@@ -1,6 +1,7 @@
 import ast
 import inspect
 import astor
+import textwrap
 
 ########
 ## IR ##
@@ -104,7 +105,7 @@ class PythonToSimple(ast.NodeVisitor):
 def Compile(f):
     """'Compile' the function f"""
     # Parse and extract the function definition AST
-    fun = ast.parse(inspect.getsource(f)).body[0]
+    fun = ast.parse(textwrap.dedent(inspect.getsource(f))).body[0]
     print(astor.dump(fun))
     
     simpleFun = PythonToSimple().visit(fun)
@@ -127,4 +128,4 @@ def test_it():
     
 if __name__ == '__main__':
     test_it()
-    
+


### PR DESCRIPTION
This is useful for unittests:
```.py
import unittest
class TestPythonToSimpleIR(unittest.TestCase):
	# Define a trivial test program to start
	def test_trivial(self):
		def trivial() -> int:
			return 5
		cc = Compile(trivial)
```

Thanks to stackoverflow:
https://stackoverflow.com/questions/41882261/reduce-indentation-of-nested-functions-in-python-code-generation