### PR TITLE
Use Python 3 super()

### DIFF
--- a/compiler.py
+++ b/compiler.py
@@ -39,7 +39,7 @@ class Ref(ast.AST):
     _fields = ['name', 'index']
 
     def __init__(self, name, index=None):
-        return super(self, Ref).__init__(name, index)
+        return super().__init__(name, index)
 
 class IntConst(ast.AST):
     _fields = ['val',]
@@ -58,7 +58,7 @@ class If(ast.AST):
     _fields = ['cond', 'body', 'elseBody']
     
     def __init__(self, cond, body, elseBody=None):
-        return super(self, If).__init__(cond, body, elseBody)
+        return super().__init__(cond, body, elseBody)
 
 class For(ast.AST):
     _fields = ['var', 'min', 'max', 'body']
@@ -127,4 +127,4 @@ def test_it():
     
 if __name__ == '__main__':
     test_it()
-    
+


### PR DESCRIPTION
The original code uses `super(self, Ref)` (and the same syntax for `If`), which causes an error, as I believe the Python 2 ordering is `super(Ref, self)`. However, both calls could use the Python 3 style.